### PR TITLE
Hostname appears to be broken for Heimdall

### DIFF
--- a/apps/heimdall.yml
+++ b/apps/heimdall.yml
@@ -59,7 +59,7 @@
         image: '{{image}}'
         pull: yes
         published_ports:
-          - '127.0.0.0.1:1112:443'
+          - '127.0.0.1:1112:443'
           - '{{ports.stdout}}1111:80'
         volumes: '{{pg_volumes}}'
         env: '{{pg_env}}'


### PR DESCRIPTION
Ansible cannot execute this particular file because of an invalid hostname entry at the `published-ports` field.

Sorry for this useless PR. I'd have loved to change some more entries, I'm just not as familiar with Ansible as I used to be.